### PR TITLE
Rubocop for ruby2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,5 @@ rvm:
   - 2.2.3
   - 2.1.9
   - 2.0.0
-  - 1.9.3
 
 script: 'bundle exec rake'

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ the `.to_cert` and `.to_cert!` methods through the CertMunger module.
 Add this line to your application's Gemfile:
 
 ```ruby
+# Ruby 2.0+:
+gem 'cert_munger', '~> 1.0'
+# Ruby 1.9 support:
 gem 'cert_munger', '~> 0.2'
 ```
 

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@ require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 require 'rubocop/rake_task'
 
-task default: [:spec, :rubocop]
+task default: %i[spec rubocop]
 
 desc 'Run specs'
 RSpec::Core::RakeTask.new(:spec)

--- a/cert_munger.gemspec
+++ b/cert_munger.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 1.9.3'
+  spec.required_ruby_version = '>= 2.0.0'
   spec.add_dependency 'logging', '~> 2.1'
 
   spec.add_development_dependency 'awesome_print', '~> 1.2'
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rack', '~> 1.5'
   spec.add_development_dependency 'rack-test', '~> 0.6'
   spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rubocop', '=0.41.1'
+  spec.add_development_dependency 'rubocop', '~> 0.48'
   spec.add_development_dependency 'rspec', '~> 3.1'
   spec.add_development_dependency 'yard', '~> 0.8'
 

--- a/lib/cert_munger/version.rb
+++ b/lib/cert_munger/version.rb
@@ -1,3 +1,3 @@
 module CertMunger
-  VERSION = '0.2.2'
+  VERSION = '1.0.0'
 end


### PR DESCRIPTION
Rubocop no longer supports Ruby 1.9 as it has been EOL'd. cert_munger is now getting a 1.0 release with a Ruby 2.0+ dependency moving forward. Version 0.2.2 still works great with Ruby 1.9 if needed.